### PR TITLE
Add deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ In order to launch Spinnaker on AWS, you would need to create a an instance runn
 
 ##Instruction - Using CloudFormation to Launch Spinnaker
 
+**Note: you can also do steps 1 and 2 by running account-setup.sh, and
+step 5 by running deploy.sh**
+
 Instructions to run Spinnaker using this Cloudformation:
 
 1. Create an EC2 role - BaseIAMRole. EC2 instances launched with Spinnaker will be associated with this role.

--- a/account-setup.sh
+++ b/account-setup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This must have this name, as it corresponds to the account used
+# by the default spinnaker AMIs (Spinnaker extrapolates from the account name
+# to the keypair name).
+KEYPAIR_NAME=my-aws-account-keypair
+
+set -ue -o pipefail
+
+if [ -z "${AWS_DEFAULT_REGION}" ]; then
+  echo 'Must set AWS_DEFAULT_REGION'
+  exit 1
+fi
+
+echo 'Creating BaseIAMRole...'
+aws iam create-role --role-name BaseIAMRole --assume-role-policy-document '{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}'
+
+if [ ! -e "${KEYPAIR_NAME}.pem" ]; then
+  echo 'Creating KeyPair (private key in ${KEYPAIR_NAME}.pem)...'
+  aws ec2 create-key-pair --key-name "$KEYPAIR_NAME" --output text --query 'KeyMaterial' > "${KEYPAIR_NAME}.pem"
+  chmod 400 "${KEYPAIR_NAME}.pem"
+else
+  echo 'Assuming existence of ${KEYPAIR_NAME}.pem means you already have a keypair.'
+fi

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 Host spinnaker-start
    HostName <spinnaker-hostname>
-   IdentityFile ~/Desktop/account-keypair.pem
+   IdentityFile <ssh key path e.g. ~/Desktop/spinnaker.pem>
    ControlMaster yes
    ControlPath ~/.ssh/spinnaker-tunnel.ctl
    RequestTTY no
@@ -9,8 +9,8 @@ Host spinnaker-start
    LocalForward 8087 127.0.0.1:8087
    User ubuntu
 
- Host spinnaker-stop
+Host spinnaker-stop
    HostName <spinnaker-hostname>
-   IdentityFile <ssh key path e.g. ~/Desktop/account-keypair.pem>
+   IdentityFile <ssh key path e.g. ~/Desktop/spinnaker.pem>
    ControlPath ~/.ssh/spinnaker-tunnel.ctl
    RequestTTY no

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Must not have a '-' (otherwise fun things happen).
+STACK_NAME=spinnaker
+
+pause() {
+  read -n1 -p 'Press c to continue...' key
+  if [ "$key" != 'c' ]; then
+    echo ' Quitting.'
+    exit 1
+  fi
+  echo
+}
+
+if [ -z "${AWS_DEFAULT_REGION}" ]; then
+  echo 'Must set AWS_DEFAULT_REGION'
+  exit 2
+fi
+
+set -ue -o pipefail
+
+echo "Deploying Spinnaker as CloudFormation stack '$STACK_NAME' in ${AWS_DEFAULT_REGION}..."
+pause
+
+aws cloudformation create-stack --stack-name "$STACK_NAME" --template-body 'file://spinnakercf.template' --capabilities CAPABILITY_IAM
+
+echo 'Run the following command to see the current state:'
+echo "  aws cloudformation describe-stacks --stack-name '$STACK_NAME'"

--- a/spinnakercf.template
+++ b/spinnakercf.template
@@ -16,18 +16,6 @@
       "AllowedValues": [
         "10.100.10.0/24"
       ]
-    },
-    "KeyName": {
-      "Description": "Key Pair Name",
-      "Type": "AWS::EC2::KeyPair::KeyName"
-    },
-    "Password": {
-      "NoEcho": "true",
-      "Type": "String",
-      "Description": "Password for Spinnaker User account",
-      "MinLength": "1",
-      "MaxLength": "41",
-      "ConstraintDescription": "the password must be between 1 and 41 characters"
     }
   },
   "Mappings": {
@@ -70,11 +58,6 @@
           "arn:aws:iam::aws:policy/PowerUserAccess"
         ],
         "Path": "/",
-        "LoginProfile": {
-          "Password": {
-            "Ref": "Password"
-          }
-        },
         "Policies": [
           {
             "PolicyName": "Spinnakerpassrole",
@@ -87,7 +70,11 @@
                   "Action": [
                     "iam:PassRole"
                   ],
-                  "Resource": "arn:aws:iam::730329488449:role/BaseIAMRole"
+                  "Resource": {
+                    "Fn::Join": [":", [
+                      "arn:aws:iam:", {"Ref": "AWS::AccountId"}, "role/BaseIAMRole"
+                    ]]
+                  }
                 }
               ]
             }
@@ -140,7 +127,11 @@
                   "Action": [
                     "iam:PassRole"
                   ],
-                  "Resource": "arn:aws:iam::730329488449:role/BaseIAMRole"
+                  "Resource": {
+                    "Fn::Join": [":", [
+                      "arn:aws:iam:", {"Ref": "AWS::AccountId"}, "role/BaseIAMRole"
+                    ]]
+                  }
                 }
               ]
             }
@@ -330,9 +321,7 @@
         "SpinnakerAttachGateway"
       ],
       "Properties": {
-        "KeyName": {
-          "Ref": "KeyName"
-        },
+        "KeyName": "my-aws-account-keypair",
         "IamInstanceProfile": {
           "Ref": "SpinnakerInstanceProfile"
         },
@@ -370,11 +359,10 @@
                 "\n",
                 "/opt/spinnaker/bin/stop_spinnaker.sh\n",
                 "/var/lib/dpkg/info/ca-certificates-java.postinst configure\n",
-                "sed -i 's/name: .*/name: default/g' /opt/spinnaker/config/spinnaker-local.yml\n",
                 "sed -i 's/SPINNAKER_AWS_ENABLED=false/SPINNAKER_AWS_ENABLED=true/g' /etc/default/spinnaker\n",
-                "sed -i 's/SPINNAKER_AWS_DEFAULT_REGION=.*/SPINNAKER_AWS_DEFAULT_REGION=us-west-2/g' /etc/default/spinnaker\n",
+                "sed -i 's/SPINNAKER_AWS_DEFAULT_REGION=.*/SPINNAKER_AWS_DEFAULT_REGION=", {"Ref": "AWS::Region"}, "/g' /etc/default/spinnaker\n",
                 "mkdir /home/spinnaker/.aws/\n",
-                "printf \"[default]\\n",
+                "printf \"[my-aws-account]\\n",
                 "aws_access_key_id= ",
                 {
                   "Ref": "SpinnakerAccessKey"


### PR DESCRIPTION
Also, removed password option (not necessary) and keypair option (has to be (account-creds-name)-keypair for Spinnaker to pick it up, though admittedly one could use two separate key-pairs).